### PR TITLE
Fix typo in rebar.config by uncommenting LOCALNET_BALANCE definition …

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -200,7 +200,7 @@
 
 			%% Your mining address will be initialized with this amount of BIG when you
 			%% launch your localnet.
-			%% {d, 'LOCALNET_BALANCE', 200_000_000}
+			{d, 'LOCALNET_BALANCE', 200_000_000}
 			export_all,
 			no_inline
 		]},


### PR DESCRIPTION
…for localnet initialization